### PR TITLE
remove_obsolete_credentials

### DIFF
--- a/ui/src/routes/profile/Credentials.svelte
+++ b/ui/src/routes/profile/Credentials.svelte
@@ -13,8 +13,6 @@
 		"GEODB_AUTH_DOMAIN",
 		"SH_CLIENT_ID",
 		"SH_CLIENT_SECRET",
-		"SH_INSTANCE_ID",
-		"SH_OWNER_ID",
 	];
 
 	const download = () => {


### PR DESCRIPTION
"SH_INSTANCE_ID"  and "SH_OWNER_ID" not provided anymore (but also not needed for EOTDL flows)