### PR TITLE
fix: handle headless/SSH environment in auth login

### DIFF
--- a/eotdl/eotdl/auth/auth.py
+++ b/eotdl/eotdl/auth/auth.py
@@ -27,7 +27,10 @@ def auth(max_t=60, interval=2):
         data = response.json()
         opened = webbrowser.open(data["login_url"])
         if not opened:
-            print(f"Please open this URL manually:\n{data['login_url']}")
+            print(f"[Headless/SSH mode] Please open this URL in your browser:\n{data['login_url']}")
+            print("After login, come back here and press Enter to continue...")
+            input()
+
         authenticated = False
         t0 = time.time()
         while not authenticated and time.time() - t0 < max_t:


### PR DESCRIPTION
## Problem
Fixes #334

`eotdl auth login` crashes on headless/SSH environments (GPU servers) 
because `webbrowser.open()` silently fails — no browser opens, the OAuth 
flow never completes, and the 60s polling timeout hits before authentication.

## Fix
Added an `input()` pause when the browser fails to open, giving the user 
time to manually open the URL, complete login, and press Enter before 
polling starts.

## Testing
Tested on a GPU server over SSH — auth now completes successfully.